### PR TITLE
Make screens wider +semver: minor

### DIFF
--- a/src/components/bot/GStracciniPage.tsx
+++ b/src/components/bot/GStracciniPage.tsx
@@ -254,7 +254,7 @@ export function GStracciniPage() {
       <Header isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
 
       <main className="w-full px-6 py-8 flex-1">
-        <div className="max-w-7xl mx-auto">
+        <div className="max-w-full mx-auto">
           {/* Header */}
           <div className="flex items-center justify-between mb-8">
             <div className="flex items-center space-x-4">

--- a/src/components/errors/ErrorsPage.tsx
+++ b/src/components/errors/ErrorsPage.tsx
@@ -305,7 +305,7 @@ export function ErrorsPage() {
       <Header isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
 
       <main className="w-full px-6 py-8 flex-1">
-        <div className="max-w-7xl mx-auto">
+        <div className="max-w-full mx-auto">
           {/* Header */}
           <div className="flex items-center justify-between mb-8">
             <div className="flex items-center space-x-4">

--- a/src/components/github/GitHubStatsPage.tsx
+++ b/src/components/github/GitHubStatsPage.tsx
@@ -721,7 +721,7 @@ export function GitHubStatsPage() {
       <Header isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
 
       <main className="w-full px-6 py-8 flex-1">
-        <div className="max-w-7xl mx-auto">
+        <div className="max-w-full mx-auto">
           {/* Header */}
           <div className="flex items-center justify-between mb-8">
             <div className="flex items-center space-x-4">

--- a/src/components/ops/OpsOverviewPage.tsx
+++ b/src/components/ops/OpsOverviewPage.tsx
@@ -310,7 +310,7 @@ export function OpsOverviewPage() {
       <Header isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
 
       <main className="w-full px-6 py-8 flex-1">
-        <div className="max-w-7xl mx-auto">
+        <div className="max-w-full mx-auto">
           {/* Header */}
           <div className="flex items-center justify-between mb-8">
             <div className="flex items-center space-x-4">

--- a/src/components/sports/SportsAgendaPage.tsx
+++ b/src/components/sports/SportsAgendaPage.tsx
@@ -263,7 +263,7 @@ export function SportsAgendaPage() {
       <Header isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
 
       <main className="w-full px-6 py-8 flex-1">
-        <div className="max-w-7xl mx-auto">
+        <div className="max-w-full mx-auto">
           {/* Header */}
           <div className="flex items-center justify-between mb-8">
             <div className="flex items-center space-x-4">


### PR DESCRIPTION
## 📑 Description
Make screens wider +semver: minor

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Widen the main content containers by replacing the fixed `max-w-7xl` constraint with `max-w-full` across multiple page components.

Enhancements:
- Use full-width layout for GStracciniPage instead of a fixed max-width
- Use full-width layout for ErrorsPage instead of a fixed max-width
- Use full-width layout for GitHubStatsPage instead of a fixed max-width
- Use full-width layout for OpsOverviewPage instead of a fixed max-width
- Use full-width layout for SportsAgendaPage instead of a fixed max-width

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated layout of several main content pages to use full-width containers instead of fixed-width, allowing content to span the entire available horizontal space. This affects the appearance of the GStraccini, Errors, GitHub Stats, Ops Overview, and Sports Agenda pages. No changes to functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->