### PR TITLE
Use HashRouter instead of BrowserRouter

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -98,15 +98,15 @@ export function Dashboard() {
             <SystemMetrics />
           </div>
 
-          {/* Middle Column - GitHub Stats */}
+          {/* Middle Column - GitHub Activity Only */}
           <div className="lg:col-span-2 space-y-6">
             <GitHubActivity />
-            <GitHubStats />
           </div>
 
-          {/* Right Column - Service Status */}
+          {/* Right Column - Service Status & GitHub Stats */}
           <div className="lg:col-span-1 space-y-6">
             <ServiceStatus />
+            <GitHubStats />
           </div>
         </div>
       </main>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import App from './App.tsx';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter basename="/projects-monitor-ui">
+    <HashRouter>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## 📑 Description
Use HashRouter instead of BrowserRouter

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Switch the application routing mechanism from BrowserRouter to HashRouter and update associated documentation

Enhancements:
- Replace BrowserRouter with HashRouter for client-side routing

Documentation:
- Update documentation to reflect HashRouter usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Dashboard layout so that GitHub statistics now appear in the right column alongside service status, while GitHub activity remains in the middle column.

* **Chores**
  * Switched routing method to use HashRouter for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->