### PR TITLE
Move WebhooksStats to middle column

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -39,7 +39,7 @@ export function Dashboard() {
       {/* Main Content */}
       <main className="w-full px-6 py-8 flex-1">
         <div className="space-y-6">
-          {/* Top Row - Quick Actions, GitHub Activity, Service Status */}
+          {/* Main Row - Quick Actions, GitHub Activity & Webhooks Stats, Service Status */}
           <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
             {/* Left Column - Quick Actions & System Metrics */}
             <div className="lg:col-span-1 space-y-6">
@@ -104,9 +104,10 @@ export function Dashboard() {
               <SystemMetrics />
             </div>
 
-            {/* Middle Column - GitHub Activity */}
+            {/* Middle Column - GitHub Activity & Webhooks Stats */}
             <div className="lg:col-span-2 space-y-6">
               <GitHubActivity />
+              <WebhooksStats />
             </div>
 
             {/* Right Column - Service Status & GitHub Stats */}
@@ -114,11 +115,6 @@ export function Dashboard() {
               <ServiceStatus />
               <GitHubStats />
             </div>
-          </div>
-
-          {/* Bottom Row - Webhooks Stats */}
-          <div className="w-full">
-            <WebhooksStats />
           </div>
         </div>
       </main>


### PR DESCRIPTION
## 📑 Description
Move WebhooksStats to middle column

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Reorganize the dashboard layout to integrate WebhooksStats into the main grid’s middle column alongside GitHubActivity

Enhancements:
- Move WebhooksStats from its own bottom row into the middle column of the main dashboard grid
- Update section comments and grid structure to reflect the new placement of WebhooksStats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the Dashboard layout by moving the Webhooks Stats section to the main row alongside GitHub Activity for a more streamlined view. No changes to functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->